### PR TITLE
Fix typo in link to ui-popup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This Ember addon support many UI components based on [semantic-ui](http://semant
 
 **Popup**
 
-- [ui-pop-up](http://wecatch.github.io/ember-semantic-ui/demo/#/ui-pop-up)
+- [ui-popup](http://wecatch.github.io/ember-semantic-ui/demo/#/ui-popup)
 
 **Message**
 


### PR DESCRIPTION
This fixes a small issue in the README where the link to the ui-popup documentation leads nowhere